### PR TITLE
feat: Including creation timestamp variables to excluded list by default

### DIFF
--- a/src/utils/ExportImportUtils.ts
+++ b/src/utils/ExportImportUtils.ts
@@ -460,6 +460,9 @@ export function saveJsonToFile({
         'lastChangeDate',
         'lastChangedBy',
         'lastChanged',
+        'createdBy',
+        'creationDate',
+        'createdDate',
       ]
     );
   }


### PR DESCRIPTION
Added to default exclusion list 'createdBy, creationDate, createdDate'. In conjuction with a CLI PR which changes -M flag instructions to include same variables as examples as well.