### PR TITLE
TRIVIR-2385 | Update Amster Authentication To Store Private Key as JWK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@rockcarver/frodo-lib",
       "version": "4.0.0-39",
       "license": "MIT",
+      "dependencies": {
+        "jose": "^6.2.3"
+      },
       "devDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "^4.7.0",
         "@jest/globals": "^30.2.0",
@@ -21,7 +24,9 @@
         "@types/mock-fs": "^4.13.1",
         "@types/node": "^25.3.0",
         "@types/node-forge": "^1.3.11",
+        "@types/node-jose": "^1.1.13",
         "@types/properties-reader": "^2.1.1",
+        "@types/sshpk": "^1.17.4",
         "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^8.56.0",
         "@typescript-eslint/parser": "^8.56.0",
@@ -2762,6 +2767,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@types/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-V91DSJ2l0h0gRhVP4oBfBzRBN9lAbPUkGDMCnwedqPKX2d84aAMc9CulOvxdw1f7DfEYx99afab+Rsm3e52jhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2944,6 +2959,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/node-jose": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@types/node-jose/-/node-jose-1.1.13.tgz",
+      "integrity": "sha512-QjMd4yhwy1EvSToQn0YI3cD29YhyfxFwj7NecuymjLys2/P0FwxWnkgBlFxCai6Y3aBCe7rbwmqwJJawxlgcXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/properties-reader": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@types/properties-reader/-/properties-reader-2.1.3.tgz",
@@ -2958,6 +2983,17 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/sshpk": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@types/sshpk/-/sshpk-1.17.4.tgz",
+      "integrity": "sha512-5gI/7eJn6wmkuIuFY8JZJ1g5b30H9K5U5vKrvOuYu+hoZLb2xcVEgxhYZ2Vhbs0w/ACyzyfkJq0hQtBfSCugjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/asn1": "*",
         "@types/node": "*"
       }
     },
@@ -8472,6 +8508,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/joycon": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,9 @@
     "@types/mock-fs": "^4.13.1",
     "@types/node": "^25.3.0",
     "@types/node-forge": "^1.3.11",
+    "@types/node-jose": "^1.1.13",
     "@types/properties-reader": "^2.1.1",
+    "@types/sshpk": "^1.17.4",
     "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^8.56.0",
     "@typescript-eslint/parser": "^8.56.0",
@@ -139,5 +141,8 @@
     "typescript": "5.8",
     "uuid": "^13.0.0",
     "winston": "^3.19.0"
+  },
+  "dependencies": {
+    "jose": "^6.2.3"
   }
 }

--- a/src/lib/FrodoLib.test.ts
+++ b/src/lib/FrodoLib.test.ts
@@ -4,6 +4,8 @@ import { autoSetupPolly } from '../utils/AutoSetupPolly';
 import fs from 'fs'
 import path from 'path';
 import { fileURLToPath } from 'url';
+import jose from 'node-jose';
+import { JwkRsa } from '../ops/JoseOps';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -92,19 +94,19 @@ describe('FrodoLib', () => {
     state0.setHost('https://instance0/am');
     const instance1 = frodo.createInstanceWithAmsterAccount(
       'https://instance1/am',
-      privateKey1
+      (await jose.JWK.asKey(privateKey1, 'pem')).toJSON(true) as JwkRsa
     );
     const instance2 = frodo.createInstanceWithAmsterAccount(
       'https://instance2/am',
-      privateKey2,
+      (await jose.JWK.asKey(privateKey2, 'pem')).toJSON(true) as JwkRsa,
       customAmsterService
     );
     expect(instance0.state.getHost()).toEqual(host0);
     expect(instance1.state.getHost()).toEqual(host1);
-    expect(instance1.state.getAmsterPrivateKey()).toEqual(privateKey1);
+    expect(await instance1.state.getAmsterPrivateKey()).toEqual((await jose.JWK.asKey(privateKey1, 'pem')).toJSON(true));
     expect(instance1.state.getAuthenticationService()).toEqual(Constants.DEFAULT_AMSTER_SERVICE);
     expect(instance2.state.getHost()).toEqual(host2);
-    expect(instance2.state.getAmsterPrivateKey()).toEqual(privateKey2);
+    expect(await instance2.state.getAmsterPrivateKey()).toEqual((await jose.JWK.asKey(privateKey2, 'pem')).toJSON(true));
     expect(instance2.state.getAuthenticationService()).toEqual(customAmsterService);
   });
 });

--- a/src/lib/FrodoLib.ts
+++ b/src/lib/FrodoLib.ts
@@ -76,7 +76,7 @@ import IdmSystemOps, { IdmSystem } from '../ops/IdmSystemOps';
 import IdpOps, { Idp } from '../ops/IdpOps';
 import InfoOps, { Info } from '../ops/InfoOps';
 import InternalRoleOps, { InternalRole } from '../ops/InternalRoleOps';
-import JoseOps, { Jose } from '../ops/JoseOps';
+import JoseOps, { Jose, JwkRsa } from '../ops/JoseOps';
 import JourneyOps, { Journey } from '../ops/JourneyOps';
 import ManagedObjectOps, { ManagedObject } from '../ops/ManagedObjectOps';
 import MappingOps, { Mapping } from '../ops/MappingOps';
@@ -315,7 +315,7 @@ export type Frodo = {
    */
   createInstanceWithAmsterAccount(
     host: string,
-    amsterPrivateKey: string,
+    amsterPrivateKey: JwkRsa,
     authenticationService?: string,
     realm?: string,
     deploymentType?: string,
@@ -473,7 +473,7 @@ function createInstance(config: StateInterface): Frodo {
 
 function createInstanceWithAmsterAccount(
   host: string,
-  amsterPrivateKey: string,
+  amsterPrivateKey: JwkRsa,
   authenticationService: string = ConstantsImpl.DEFAULT_AMSTER_SERVICE,
   realm: string = undefined,
   deploymentType: string = undefined,

--- a/src/ops/AdminOps.ts
+++ b/src/ops/AdminOps.ts
@@ -1864,7 +1864,7 @@ export async function generateRfc7523ClientAuthNArtefacts({
   };
 
   // create and sign JWT
-  const jwt = createSignedJwtToken(payload, jwk);
+  const jwt = await createSignedJwtToken(payload, jwk);
 
   // create oauth2 client
   const clientData: OAuth2ClientSkeleton = cloneDeep(OAUTH2_CLIENT);

--- a/src/ops/AuthenticateOps.test.ts
+++ b/src/ops/AuthenticateOps.test.ts
@@ -40,6 +40,8 @@ import Constants from '../shared/Constants';
 import fs from 'fs'
 import path from 'path';
 import { fileURLToPath } from 'url';
+import jose from 'node-jose';
+import { JwkRsa } from './JoseOps';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -148,7 +150,7 @@ describe('AuthenticateOps', () => {
             'utf8'
           );
           state.setDeploymentType(undefined);
-          state.setAmsterPrivateKey(privateKey);;
+          state.setAmsterPrivateKey((await jose.JWK.asKey(privateKey, 'pem')).toJSON(true) as JwkRsa);
           const result = await AuthenticateOps.getTokens({ autoRefresh: false, state });
           expect(result).toBeTruthy();
           expect(result.subject).toEqual("user " + state.getUsername());
@@ -158,7 +160,7 @@ describe('AuthenticateOps', () => {
             subject: expect.any(String),
           });
           expect(state.getDeploymentType()).toEqual(Constants.CLASSIC_DEPLOYMENT_TYPE_KEY);
-          expect(state.getAmsterPrivateKey()).toEqual(privateKey);
+          expect(await state.getAmsterPrivateKey()).toEqual((await jose.JWK.asKey(privateKey, 'pem')).toJSON(true));
           expect(state.getAuthenticationService()).toEqual(Constants.DEFAULT_AMSTER_SERVICE);
           expect(state.getUsername()).toEqual(Constants.DEFAULT_CLASSIC_USERNAME);
           expect(state.getCookieName()).toBeTruthy();
@@ -184,7 +186,7 @@ describe('AuthenticateOps', () => {
           state.setAuthenticationService(authenticationService);
           state.setUsername(username);
           state.setDeploymentType(undefined);
-          state.setAmsterPrivateKey(privateKey);
+          state.setAmsterPrivateKey((await jose.JWK.asKey(privateKey, 'pem')).toJSON(true) as JwkRsa);
           const result = await AuthenticateOps.getTokens({ autoRefresh: false, state });
           expect(result).toBeTruthy();
           expect(result.subject).toEqual("user " + state.getUsername());
@@ -194,7 +196,7 @@ describe('AuthenticateOps', () => {
             subject: expect.any(String)
           });
           expect(state.getDeploymentType()).toEqual(Constants.CLASSIC_DEPLOYMENT_TYPE_KEY);
-          expect(state.getAmsterPrivateKey()).toEqual(privateKey);
+          expect(await state.getAmsterPrivateKey()).toEqual((await jose.JWK.asKey(privateKey, 'pem')).toJSON(true) as JwkRsa);
           expect(state.getAuthenticationService()).toEqual(authenticationService);
           expect(state.getUsername()).toEqual(username);
           expect(state.getCookieName()).toBeTruthy();

--- a/src/ops/AuthenticateOps.ts
+++ b/src/ops/AuthenticateOps.ts
@@ -2,8 +2,6 @@ import { createHash, randomBytes } from 'crypto';
 import { URL } from 'url';
 
 import { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
-import jose from 'node-jose';
-import sshpk from 'sshpk';
 import c from 'tinyrainbow';
 import { v4 } from 'uuid';
 
@@ -1450,7 +1448,7 @@ export async function getTokens({
       state.getPassword() == null &&
       !state.getServiceAccountId() &&
       !state.getServiceAccountJwk() &&
-      !state.getAmsterPrivateKey()
+      !(await state.getAmsterPrivateKey())
     ) {
       usingConnectionProfile = await loadConnectionProfile({ state });
 
@@ -1535,7 +1533,7 @@ export async function getTokens({
       !forceLoginAsUser &&
       (state.getDeploymentType() === Constants.CLASSIC_DEPLOYMENT_TYPE_KEY ||
         state.getDeploymentType() === undefined) &&
-      state.getAmsterPrivateKey()
+      (await state.getAmsterPrivateKey())
     ) {
       if (!state.getAuthenticationService()) {
         state.setAuthenticationService(Constants.DEFAULT_AMSTER_SERVICE);
@@ -1562,18 +1560,14 @@ export async function getTokens({
               `Expected a single HiddenValueCallback for Amster authentication, but got a ${callback.type}`
             );
           }
-          const key = await jose.JWK.asKey(state.getAmsterPrivateKey(), 'pem');
+          const key = await state.getAmsterPrivateKey();
           const payload = {
             sub: state.getUsername(),
             nonce: getCallbackValue('value', callback.output),
           };
           const header = {
             typ: 'jwt',
-            kid: sshpk
-              .parsePrivateKey(state.getAmsterPrivateKey())
-              .toPublic()
-              .toString('ssh')
-              .split(' ')[1],
+            kid: (await state.getAmsterPrivateKey()).kid,
           };
           const jwt = await createSignedJwtToken(payload, key, header);
           return fillCallbacks({

--- a/src/ops/ConnectionProfileOps.ts
+++ b/src/ops/ConnectionProfileOps.ts
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 
+import jose from 'node-jose';
+
 import { IdObjectSkeletonInterface } from '../api/ApiTypes';
 import Constants from '../shared/Constants';
 import { State } from '../shared/State';
@@ -538,7 +540,9 @@ export async function loadConnectionProfileByHost({
   state.setServiceAccountId(conn.svcacctId);
   state.setServiceAccountJwk(conn.svcacctJwk);
   state.setServiceAccountScope(conn.svcacctScope);
-  state.setAmsterPrivateKey(conn.amsterPrivateKey);
+  state.setAmsterPrivateKey(
+    (await jose.JWK.asKey(conn.amsterPrivateKey, 'pem')).toJSON(true) as JwkRsa
+  );
   return true;
 }
 
@@ -711,9 +715,9 @@ export async function saveConnectionProfile({
     }
 
     // Amster account
-    if (state.getAmsterPrivateKey()) {
+    if (await state.getAmsterPrivateKey()) {
       profile.encodedAmsterPrivateKey = await dataProtection.encrypt(
-        state.getAmsterPrivateKey()
+        JSON.stringify(await state.getAmsterPrivateKey())
       );
     }
 

--- a/src/ops/JoseOps.ts
+++ b/src/ops/JoseOps.ts
@@ -89,19 +89,22 @@ export async function createSignedJwtToken(
   payload: string | object,
   jwkJson: JwkRsa,
   header: object = {}
-) {
+): Promise<string> {
   const key = await jose.JWK.asKey(jwkJson);
   if (typeof payload === 'object') {
     payload = JSON.stringify(payload);
   }
   const jwt = await jose.JWS.createSign(
-    { alg: 'RS256', compact: true, fields: header },
-    // https://github.com/cisco/node-jose/issues/253
-    { key, reference: false }
+    { alg: 'RS256', format: 'compact', fields: header },
+    key
   )
     .update(payload)
-    .final();
-  return jwt;
+    .final()
+    .then((result) => {
+      return result;
+    });
+  // @ts-expect-error since the format is 'compact' a string is returned
+  return jwt as string;
 }
 
 export async function verifySignedJwtToken(jwt: string, jwkJson: JwkRsaPublic) {

--- a/src/ops/JoseOps.ts
+++ b/src/ops/JoseOps.ts
@@ -36,26 +36,26 @@ export default (_state: State) => {
 };
 
 export interface JwkInterface {
-  kty: string;
+  kty?: string;
   use?: string;
   key_ops?: string[];
-  alg: string;
+  alg?: string;
   kid?: string;
   x5u?: string;
-  x5c?: string;
+  x5c?: string | string[];
   x5t?: string;
   'x5t#S256'?: string;
 }
 
 export type JwkRsa = JwkInterface & {
-  d: string;
-  dp: string;
-  dq: string;
-  e: string;
-  n: string;
-  p: string;
-  q: string;
-  qi: string;
+  d?: string;
+  dp?: string;
+  dq?: string;
+  e?: string;
+  n?: string;
+  p?: string;
+  q?: string;
+  qi?: string;
 };
 
 export type JwkRsaPublic = JwkInterface & {

--- a/src/shared/State.test.ts
+++ b/src/shared/State.test.ts
@@ -12,6 +12,7 @@ import Constants from './Constants';
 import fs from 'fs'
 import path from 'path';
 import { fileURLToPath } from 'url';
+import jose from 'node-jose';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -323,22 +324,22 @@ describe('State', () => {
       expect(state.setAmsterPrivateKey).toBeDefined();
     });
 
-    test('1: Method getAmsterPrivateKey is implemented', () => {
+    test('1: Method getAmsterPrivateKey is implemented', async () => {
       expect(state.getAmsterPrivateKey).toBeDefined();
     });
 
-    test("2: Amster private key value should be undefined if it hasn't been set before or defined if FRODO_AMSTER_PRIVATE_KEY env variable has been set or if set explicitly", () => {
+    test("2: Amster private key value should be undefined if it hasn't been set before or defined if FRODO_AMSTER_PRIVATE_KEY env variable has been set or if set explicitly", async () => {
       delete process.env.FRODO_AMSTER_PRIVATE_KEY;
-      expect(state.getAmsterPrivateKey()).toBeUndefined();
+      expect(await state.getAmsterPrivateKey()).toBeUndefined();
       process.env.FRODO_AMSTER_PRIVATE_KEY = privateKey1;
       // Tests that privateKey1, in PKCS#8 format, is still in PKCS#8 format after being parsed
-      expect(state.getAmsterPrivateKey()).toEqual(privateKey1);
-      state.setAmsterPrivateKey(privateKey2);
+      expect(await state.getAmsterPrivateKey()).toEqual((await jose.JWK.asKey(privateKey1, 'pem')).toJSON(true));
+      state.setAmsterPrivateKey((await jose.JWK.asKey(privateKey2, 'pem')).toJSON(true) as JwkRsa);
       // Tests that privateKey2, in PKCS#1 format, is still in PKCS#1 format since we set it directly
-      expect(state.getAmsterPrivateKey()).toEqual(privateKey2);
+      expect(await state.getAmsterPrivateKey()).toEqual((await jose.JWK.asKey(privateKey2, 'pem')).toJSON(true));
     });
 
-    test("3: Amster private key value should be undefined and throw error if FRODO_AMSTER_PRIVATE_KEY is encrypted and FRODO_AMSTER_PASSPHRASE is not provided, or defined if FRODO_AMSTER_PASSPHRASE is provided.", () => {
+    test("3: Amster private key value should be undefined and throw error if FRODO_AMSTER_PRIVATE_KEY is encrypted and FRODO_AMSTER_PASSPHRASE is not provided, or defined if FRODO_AMSTER_PASSPHRASE is provided.", async () => {
       delete process.env.FRODO_AMSTER_PRIVATE_KEY;
       delete process.env.FRODO_AMSTER_PASSPHRASE;
       state.setAmsterPrivateKey(undefined);
@@ -346,7 +347,7 @@ describe('State', () => {
       expect(state.getAmsterPrivateKey).toThrow("The PEM format key (unnamed) is encrypted (password-protected), and no passphrase was provided in `options`");
       process.env.FRODO_AMSTER_PASSPHRASE = 'test';
       // Should be in PKCS#8 format now instead of OpenSSH
-      expect(state.getAmsterPrivateKey()).not.toEqual(privateKey3);
+      expect(await state.getAmsterPrivateKey()).not.toEqual((await jose.JWK.asKey(privateKey3, 'pem')).toJSON(true));
     });
   });
 

--- a/src/shared/State.test.ts
+++ b/src/shared/State.test.ts
@@ -6,13 +6,15 @@
  * Note: FRODO_DEBUG=1 is optional and enables debug logging for some output
  * in case things don't function as expected
  */
-import { state } from '../index';
+import { FrodoError, state } from '../index';
 import { JwkRsa } from '../ops/JoseOps';
 import Constants from './Constants';
 import fs from 'fs'
 import path from 'path';
 import { fileURLToPath } from 'url';
 import jose from 'node-jose';
+import * as panvaJose from 'jose';
+import SshPK from 'sshpk';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -320,6 +322,41 @@ describe('State', () => {
       ),
       'utf8'
     );
+
+    // Generates JWK, with passed in PEM key, using Jose (panva)
+    // This ensures that if crypto and Jose generate the same outcome, then the JWK is truthy
+    async function convertKey(key: string, passphrase?: string, isEdBased?: boolean) {
+      if (isEdBased) {
+        const pemKeyString = SshPK.parsePrivateKey(key, 'auto', {
+          passphrase,
+        });
+  
+        //@ts-expect-error k does exist in part
+        const seed = pemKeyString.part.k.data; // 32 bytes, the private key
+        //@ts-expect-error A does exist in part
+        const pubKey = pemKeyString.toPublic().part.A.data; // 32 bytes, the public key
+  
+        // base64url encode without padding
+        function b64url(bytes) {
+          return btoa(String.fromCharCode(...bytes))
+            .replace(/\+/g, '-')
+            .replace(/\//g, '_')
+            .replace(/=+$/, '');
+        }
+  
+        const jwk = {
+          kty: 'OKP',
+          crv: 'Ed25519',
+          d: b64url(seed),
+          x: b64url(pubKey),
+        } as panvaJose.JWK;
+  
+        return await panvaJose.exportJWK(await panvaJose.importJWK(jwk, 'EdDSA', { extractable: true }));
+      }
+
+      return (await jose.JWK.asKey(key, 'pem')).toJSON(true) as JwkRsa;
+    }
+
     test('0: Method setAmsterPrivateKey is implemented', () => {
       expect(state.setAmsterPrivateKey).toBeDefined();
     });
@@ -333,10 +370,12 @@ describe('State', () => {
       expect(await state.getAmsterPrivateKey()).toBeUndefined();
       process.env.FRODO_AMSTER_PRIVATE_KEY = privateKey1;
       // Tests that privateKey1, in PKCS#8 format, is still in PKCS#8 format after being parsed
-      expect(await state.getAmsterPrivateKey()).toEqual((await jose.JWK.asKey(privateKey1, 'pem')).toJSON(true));
-      state.setAmsterPrivateKey((await jose.JWK.asKey(privateKey2, 'pem')).toJSON(true) as JwkRsa);
+      expect(await state.getAmsterPrivateKey()).toEqual(await convertKey(privateKey1, process.env.FRODO_AMSTER_PASSPHRASE));
+      
+      const convertedKey = await convertKey(privateKey2, process.env.FRODO_AMSTER_PASSPHRASE)
+      state.setAmsterPrivateKey(convertedKey);
       // Tests that privateKey2, in PKCS#1 format, is still in PKCS#1 format since we set it directly
-      expect(await state.getAmsterPrivateKey()).toEqual((await jose.JWK.asKey(privateKey2, 'pem')).toJSON(true));
+      expect(await state.getAmsterPrivateKey()).toEqual(await convertKey(privateKey2, process.env.FRODO_AMSTER_PASSPHRASE));
     });
 
     test("3: Amster private key value should be undefined and throw error if FRODO_AMSTER_PRIVATE_KEY is encrypted and FRODO_AMSTER_PASSPHRASE is not provided, or defined if FRODO_AMSTER_PASSPHRASE is provided.", async () => {
@@ -344,10 +383,18 @@ describe('State', () => {
       delete process.env.FRODO_AMSTER_PASSPHRASE;
       state.setAmsterPrivateKey(undefined);
       process.env.FRODO_AMSTER_PRIVATE_KEY = privateKey3;
-      expect(state.getAmsterPrivateKey).toThrow("The PEM format key (unnamed) is encrypted (password-protected), and no passphrase was provided in `options`");
+      try {
+        await state.getAmsterPrivateKey()
+      } catch (error) {
+        expect(error).toStrictEqual(new FrodoError("The PEM format key (unnamed) is encrypted (password-protected), and no passphrase was provided in `options`"));
+      }
       process.env.FRODO_AMSTER_PASSPHRASE = 'test';
+
+      const convertedKey = await convertKey(privateKey3, 'test', true);
+      state.setAmsterPrivateKey(convertedKey);
+      
       // Should be in PKCS#8 format now instead of OpenSSH
-      expect(await state.getAmsterPrivateKey()).not.toEqual((await jose.JWK.asKey(privateKey3, 'pem')).toJSON(true));
+      expect(await state.getAmsterPrivateKey()).toEqual(convertedKey);
     });
   });
 

--- a/src/shared/State.ts
+++ b/src/shared/State.ts
@@ -18,7 +18,7 @@ import {
   ProgressIndicatorStatusType,
   ProgressIndicatorType,
 } from '../utils/Console';
-import { convertPrivateKeyToPem } from '../utils/CryptoUtils';
+import { getPrivateKey } from '../utils/CryptoUtils';
 import { cloneDeep, mergeDeep } from '../utils/JsonUtils';
 import { getPackageVersion } from './Version';
 
@@ -91,8 +91,8 @@ export type State = {
   getServiceAccountJwk(): JwkRsa;
   setServiceAccountScope(scope: string): void;
   getServiceAccountScope(): string;
-  setAmsterPrivateKey(key: string): void;
-  getAmsterPrivateKey(): string;
+  setAmsterPrivateKey(key: JwkRsa): void;
+  getAmsterPrivateKey(): Promise<JwkRsa>;
   setUseBearerTokenForAmApis(useBearerTokenForAmApis: boolean): void;
   getUseBearerTokenForAmApis(): boolean;
   setBearerTokenMeta(token: AccessTokenMetaType): void;
@@ -386,12 +386,12 @@ export default (initialState: StateInterface): State => {
       return state.serviceAccountScope;
     },
 
-    setAmsterPrivateKey(key: string) {
+    async setAmsterPrivateKey(key: JwkRsa) {
       state.amsterPrivateKey = key;
     },
-    getAmsterPrivateKey(): string {
+    async getAmsterPrivateKey(): Promise<JwkRsa> {
       if (!state.amsterPrivateKey && process.env.FRODO_AMSTER_PRIVATE_KEY) {
-        state.amsterPrivateKey = convertPrivateKeyToPem({
+        state.amsterPrivateKey = await getPrivateKey({
           key: process.env.FRODO_AMSTER_PRIVATE_KEY,
           passphrase: process.env.FRODO_AMSTER_PASSPHRASE || undefined,
         });
@@ -684,7 +684,7 @@ export interface StateInterface {
   serviceAccountJwk?: JwkRsa;
   serviceAccountScope?: string;
   // Amster settings
-  amsterPrivateKey?: string;
+  amsterPrivateKey?: JwkRsa;
   // bearer token settings
   useBearerTokenForAmApis?: boolean;
   bearerToken?: AccessTokenMetaType;

--- a/src/test/snapshots/utils/CryptoUtils.test.js.snap
+++ b/src/test/snapshots/utils/CryptoUtils.test.js.snap
@@ -1,11 +1,12 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`CryptoUtils getPrivateKey() 3: PEM PKCS#8 RSA 1`] = `
+exports[`CryptoUtils getPrivateKey() 2: PEM PKCS#1 RSA 1`] = `
 {
   "d": "Y8uMu7sYCRR9fci0U-TewgYNDHXocevnU7o8ursJOhCUrnreeLzjga-BCAOX7eRTJTbVq8IzNG4NbA4-zfb9xQ",
   "dp": "hl4xOJGVYRiQU3BGCjskJBo24bJ_YSjZy5Y-VTw0miU",
   "dq": "ij9M7SNCEfc1gaXiSgMHmazOvD6gDy7mHqMrL0D20zk",
   "e": "AQAB",
+  "kid": "qkD8YKN_6VgpUBkeKFQPgGgigUelFgCnecVSy5yuaCs",
   "kty": "RSA",
   "n": "hVdznmYTyC1ry4bHHkiCbyoL_HIJDKCSeMAyYaa9ZGhhvN8UrpS480u2pehxBmJiVZtD80Ui7ejidhisSQPT-Q",
   "p": "ubYp8-Z2owLIXCvjrj8-VJRU7u-73YkMUol2se-0n7s",
@@ -14,12 +15,13 @@ exports[`CryptoUtils getPrivateKey() 3: PEM PKCS#8 RSA 1`] = `
 }
 `;
 
-exports[`CryptoUtils getPrivateKey() 5: PEM PKCS#8 ECDSA 1`] = `
+exports[`CryptoUtils getPrivateKey() 3: PEM PKCS#8 RSA 1`] = `
 {
   "d": "T3iwNb4kjdSTjZSdSHB7EVGYlpokw0gadQSqXuSyfIZKn7k70VlNQynPe3Swd5QUgvMhJwBj5sw2utvWN0DQUlbQtt-TZiVdAdzPCF9zyDAWJSOHT4xirjWh7_hLON32ONOBdVWOHuaPHpj88nS8084iOTVs5875ZcKgt3EgDKE",
   "dp": "mlNulEMq1qTcWasM3z9sVgLxKjART40-lIVJtdRk_P7v-qvvyp6ayXuneH4NR965YCKDGHr80tipkgvT6nVuIQ",
   "dq": "eOMdj6XQ7cPVTde8yxRQ9GwrQUV1tnLS0lHGxvsRkKeJ5JE_FXf-ptKEWiZuEHPQ0N3fFjurQtgfECrE0f9RnQ",
   "e": "AQAB",
+  "kid": "6YEBmzs4-h-PV2f9UbxaIL9qHiZHrimNdiXY-FBS3lg",
   "kty": "RSA",
   "n": "zdJe-pIq1VRgSopnTQkMojIYqo176YJuLk4IeSWOe--aP2OX00vKGoQrZIe5JW0_9RIJ9L7osXyFKk2a4r4_gqURdJqca_S5tkUTcQsK_Kunj1X78Gk9RqJ87HfezJLPJDg2D0mVkPLmpVKBxjR8KjQ7GKLXtOv3iwOGIjLsTKc",
   "p": "-ADCStx6PhfMEKsvTrTVT5qareNsNJHFlQjKJeC05RHr5c-HnioxMHafF5_rJXmy-7FtwhgQDmWYFyJfx9BycQ",
@@ -28,40 +30,44 @@ exports[`CryptoUtils getPrivateKey() 5: PEM PKCS#8 ECDSA 1`] = `
 }
 `;
 
-exports[`CryptoUtils getPrivateKey() 6: PEM PKCS#8 ED25519 1`] = `
+exports[`CryptoUtils getPrivateKey() 5: PEM PKCS#8 ECDSA 1`] = `
 {
   "crv": "P-256",
   "d": "-RC9AdyPFXArluWk6KMDJZnRg6aXNXx4mTk3uwwKSqg",
+  "kid": "asAZud7B6VQKl78SQsY3pxdkZeTJu-SXKU1Pnx8NQIw",
   "kty": "EC",
   "x": "DymV0MRNFZOUvBc5-1bI9H-PA4qY7NlF2sf4xew1w8A",
   "y": "ebqNoUCJImoX1IvZdHb7QNiBv02S4fjhdCE3GQ92WQ8",
 }
 `;
 
-exports[`CryptoUtils getPrivateKey() 7: PEM PKCS#8 ED25519 Encrypted 1`] = `
+exports[`CryptoUtils getPrivateKey() 6: PEM PKCS#8 ED25519 1`] = `
 {
   "crv": "Ed25519",
   "d": "EVBej4SZp1F00OIGC7iHOg77j5oHJ64Tl-bmwa4xL_s",
+  "kid": "8aANYc0R78zxs8a_-maLqCGfW1EIDuuFgWwXXzXVYIg",
   "kty": "OKP",
   "x": "qZWTR-5H4FEh_HkZPNMh0lVmZky5TbpsLWQBaTFnN4A",
 }
 `;
 
-exports[`CryptoUtils getPrivateKey() 8: OpenSSH RSA 1`] = `
+exports[`CryptoUtils getPrivateKey() 7: PEM PKCS#8 ED25519 Encrypted 1`] = `
 {
   "crv": "Ed25519",
   "d": "e1hMcHhkbE6jxIa0R-gupTYvT3iIF1o2e93LmLTQfHQ",
+  "kid": "yDPfxeqAcoAMumwalLCn3xM4veu9WKoFBkN7LYeEmBM",
   "kty": "OKP",
   "x": "vwEr3F6eO4dtGsQcaX3GWhP7jeG4JuIJBzhAPo11D08",
 }
 `;
 
-exports[`CryptoUtils getPrivateKey() 9: OpenSSH ECDSA 1`] = `
+exports[`CryptoUtils getPrivateKey() 8: OpenSSH RSA 1`] = `
 {
   "d": "QXrH1tSvdkTqt2o02Sd8SwVOEvSQDouZUdIaXlrYG3wd9EfO5_yn8Vl8jBSqYRFCbXL2bWagfmyR3_Gcy1vWpvsTavcxBjdjIttrPF0WhtPbFoy48mGhXIyTWor56248e6J37mFFtkR_gfRjnvS5JANhpPjoTLhvGioGzgYi44E",
   "dp": "",
   "dq": "",
   "e": "AQAB",
+  "kid": "NHRgn2uKvQCgAxjVy-z1eWpC95NXfguEHu65rVtRsgk",
   "kty": "RSA",
   "n": "yrB0SnD2N6xvlXYcxRgzTErJZfBE6RIJ7qE0lEF3-aqzP5Ls5J6jjIUTwI8MHMX0eSxNMjdm1pycqbWS8mq4HwOwcAslObACU7BVm9yaKZVGbzFWr2Yps13wYgHC0HJzQ0biolsOk0lpABV3Sn1icY80MTQExV0R2NaJLsgSkXU",
   "p": "63p9Gf5U4UOCXBopSA4VV38o5FfTpmpvomJgP3d1qGFTxi0yx9mL4LC9QJKdP8Dyxad66FhCIlEi_2iWzBFUCQ",
@@ -70,31 +76,49 @@ exports[`CryptoUtils getPrivateKey() 9: OpenSSH ECDSA 1`] = `
 }
 `;
 
-exports[`CryptoUtils getPrivateKey() 10: OpenSSH ED25519 1`] = `
+exports[`CryptoUtils getPrivateKey() 9: OpenSSH ECDSA 1`] = `
 {
   "crv": "P-256",
   "d": "LBIrlWvr1ioOIXQpJaWrvFTDtyPX82rRKy9co6BZNrg",
+  "kid": "pRypFJFItr8d9HRnBBc1a7iFXMPQI5AHi8iQiFitDKY",
   "kty": "EC",
   "x": "XO26UxPR1doE9esP7RKS7LwM5Bt456oZR2GPduPP-EE",
   "y": "8SEHztEjs_ZN9LS7D2ecOXmSh069aonmruKtZdXUkwE",
 }
 `;
 
-exports[`CryptoUtils getPrivateKey() 11: OpenSSH ED25519 Encrypted 1`] = `
+exports[`CryptoUtils getPrivateKey() 10: OpenSSH ED25519 1`] = `
 {
   "crv": "Ed25519",
   "d": "evSJ38PaEsGn4mfJYSJ3dNfe6G1MANPga7Xsv-Gb6HU",
+  "kid": "Fy24AzeXGQv4BJL1Os3yyYhl02OZxy08bqHFtuYdsmw",
   "kty": "OKP",
   "x": "A2T-HCZ3LJ6ss5Y8BZGXvzlE-438qqfWA4rWyG8eyd0",
 }
 `;
 
-exports[`CryptoUtils getPrivateKey() 12: DNSSEC RSASHA512 1`] = `
+exports[`CryptoUtils getPrivateKey() 11: OpenSSH ED25519 Encrypted 1`] = `
 {
   "crv": "Ed25519",
   "d": "_JJgrN2LFsG4XZIChhsFO5HHsXz_-j7GgyJQ8tNfW38",
+  "kid": "1K4Mc6pmIxM5jDL6zOsOJMA6QVo43MwLoymq1JwgeRo",
   "kty": "OKP",
   "x": "Sw-zS0kVH8li5P8zBVlVJ5kQ-oPLE33Gwbof8GhmeEs",
+}
+`;
+
+exports[`CryptoUtils getPrivateKey() 12: DNSSEC RSASHA512 1`] = `
+{
+  "d": "p-u2H7cEWafjcqefz5DwBhi-zhkWUtVcxay_Ne3l_URMgu0Ft_zGzC2Gr128hIhbsBrGtcJjQ3ECu7kJS8_y8HaE0zku19-3eh6bIekgtLzbsgQXkgqjVlXxkkQmG-1C9J3rknMyDsoV9ncSBd1VIHKvrvRBPysIr9VlbTWc0Q",
+  "dp": "93i4X_sIPtjL4bbnFVdzXnNGbR9F8wbon_9NrKA50fXqbfjXhIeUiWyRB67UChnfIpqFoISrWP4yr5fbZrmZpQ",
+  "dq": "L1eaK8oAaV_qXK3_ifICAloodFsk2XWrZkCuBCc9g1ovA-nXmBHjTJv3k11ZhfziuJ3BQSxBlhEbFs5cWdsLdQ",
+  "e": "AQAB",
+  "kid": "D50p-bG8tRZL4qtEah-v-1bS-sLSaI660Nfz1f3IQFM",
+  "kty": "RSA",
+  "n": "9w9AzSIL3a312ovgUTMfw7qCzEZ2UkYonXrg71b3DXwCncGFXLQ5EB3myWebyHzf9OkkgkJZx9c1OPy375fmoXeuiQ5FElENAVddPI-vvkMBQbXwGRvnVXE_Akz7g1vT-LdqEr1H_wmYPUr39twdDQlQtwWO_D1tpovBnf7YI38",
+  "p": "_iMv_L2IKaicQy2c5zYuULhaDLcHXbvmpL19Uvi3kh5T6w66U81-HVoU_RprAxSVXuR5gnv3zq6TPewZcVOG6w",
+  "q": "-N7JQ4piWJdfb0hDrfogVAeINsbrSxqxC1tnPhnIu-xA7mDz0ke7y6nspJ8JADv5dbt-xtffB1hM4NabM7aYvQ",
+  "qi": "zYWYdN2jwzNp5F2LJMqqda31BzUhHMDkv1NE_33IvI2BL_tmx2MNREfauHQ5P0_a9bjQR0db1DvyWvsZ1IrxkQ",
 }
 `;
 
@@ -112,20 +136,6 @@ exports[`CryptoUtils getPrivateKey() 13: JWK RSA 1`] = `
   "q": "p9mCXS5mmKkJrCZGfy0h3yZOJkiDIKi_hwu95VcX_vZ8SM1LKJgwDjPWyvGxPZPC-fXm86Gaj6aN6Q3AJc-G5Q",
   "qi": "l2m2wzcOpgI4zaD4yCB880Kg4s4iUz_k3vWgvjhWrqPmor5zPDdWp1LEwRFyoWdGPJg2vqALzE_57Nc3hNLa5A",
   "use": "sig",
-}
-`;
-
-exports[`CryptoUtils getPrivateKey() 13: JWK RSA 2`] = `
-{
-  "d": "p-u2H7cEWafjcqefz5DwBhi-zhkWUtVcxay_Ne3l_URMgu0Ft_zGzC2Gr128hIhbsBrGtcJjQ3ECu7kJS8_y8HaE0zku19-3eh6bIekgtLzbsgQXkgqjVlXxkkQmG-1C9J3rknMyDsoV9ncSBd1VIHKvrvRBPysIr9VlbTWc0Q",
-  "dp": "93i4X_sIPtjL4bbnFVdzXnNGbR9F8wbon_9NrKA50fXqbfjXhIeUiWyRB67UChnfIpqFoISrWP4yr5fbZrmZpQ",
-  "dq": "L1eaK8oAaV_qXK3_ifICAloodFsk2XWrZkCuBCc9g1ovA-nXmBHjTJv3k11ZhfziuJ3BQSxBlhEbFs5cWdsLdQ",
-  "e": "AQAB",
-  "kty": "RSA",
-  "n": "9w9AzSIL3a312ovgUTMfw7qCzEZ2UkYonXrg71b3DXwCncGFXLQ5EB3myWebyHzf9OkkgkJZx9c1OPy375fmoXeuiQ5FElENAVddPI-vvkMBQbXwGRvnVXE_Akz7g1vT-LdqEr1H_wmYPUr39twdDQlQtwWO_D1tpovBnf7YI38",
-  "p": "_iMv_L2IKaicQy2c5zYuULhaDLcHXbvmpL19Uvi3kh5T6w66U81-HVoU_RprAxSVXuR5gnv3zq6TPewZcVOG6w",
-  "q": "-N7JQ4piWJdfb0hDrfogVAeINsbrSxqxC1tnPhnIu-xA7mDz0ke7y6nspJ8JADv5dbt-xtffB1hM4NabM7aYvQ",
-  "qi": "zYWYdN2jwzNp5F2LJMqqda31BzUhHMDkv1NE_33IvI2BL_tmx2MNREfauHQ5P0_a9bjQR0db1DvyWvsZ1IrxkQ",
 }
 `;
 

--- a/src/test/snapshots/utils/CryptoUtils.test.js.snap
+++ b/src/test/snapshots/utils/CryptoUtils.test.js.snap
@@ -1,166 +1,143 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`CryptoUtils convertPrivateKeyToPem() 2: PEM PKCS#1 RSA 1`] = `
-"-----BEGIN PRIVATE KEY-----
-MIIBVgIBADANBgkqhkiG9w0BAQEFAASCAUAwggE8AgEAAkEAhVdznmYTyC1ry4bH
-HkiCbyoL/HIJDKCSeMAyYaa9ZGhhvN8UrpS480u2pehxBmJiVZtD80Ui7ejidhis
-SQPT+QIDAQABAkBjy4y7uxgJFH19yLRT5N7CBg0Mdehx6+dTujy6uwk6EJSuet54
-vOOBr4EIA5ft5FMlNtWrwjM0bg1sDj7N9v3FAiEAubYp8+Z2owLIXCvjrj8+VJRU
-7u+73YkMUol2se+0n7sCIQC3zxfkfveyWlLEylxcg6IqsWnZjdj5iKjBqdaWwkUd
-2wIhAIZeMTiRlWEYkFNwRgo7JCQaNuGyf2Eo2cuWPlU8NJolAiEAij9M7SNCEfc1
-gaXiSgMHmazOvD6gDy7mHqMrL0D20zkCIQCfwAhSWIYshBCwE8mYOoXfKgN+/pYI
-x/kB7yKLhZkddg==
------END PRIVATE KEY-----
-"
+exports[`CryptoUtils getPrivateKey() 3: PEM PKCS#8 RSA 1`] = `
+{
+  "d": "Y8uMu7sYCRR9fci0U-TewgYNDHXocevnU7o8ursJOhCUrnreeLzjga-BCAOX7eRTJTbVq8IzNG4NbA4-zfb9xQ",
+  "dp": "hl4xOJGVYRiQU3BGCjskJBo24bJ_YSjZy5Y-VTw0miU",
+  "dq": "ij9M7SNCEfc1gaXiSgMHmazOvD6gDy7mHqMrL0D20zk",
+  "e": "AQAB",
+  "kty": "RSA",
+  "n": "hVdznmYTyC1ry4bHHkiCbyoL_HIJDKCSeMAyYaa9ZGhhvN8UrpS480u2pehxBmJiVZtD80Ui7ejidhisSQPT-Q",
+  "p": "ubYp8-Z2owLIXCvjrj8-VJRU7u-73YkMUol2se-0n7s",
+  "q": "t88X5H73slpSxMpcXIOiKrFp2Y3Y-YiowanWlsJFHds",
+  "qi": "n8AIUliGLIQQsBPJmDqF3yoDfv6WCMf5Ae8ii4WZHXY",
+}
 `;
 
-exports[`CryptoUtils convertPrivateKeyToPem() 3: PEM PKCS#8 RSA 1`] = `
-"-----BEGIN PRIVATE KEY-----
-MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBAM3SXvqSKtVUYEqK
-Z00JDKIyGKqNe+mCbi5OCHkljnvvmj9jl9NLyhqEK2SHuSVtP/USCfS+6LF8hSpN
-muK+P4KlEXSanGv0ubZFE3ELCvyrp49V+/BpPUaifOx33sySzyQ4Ng9JlZDy5qVS
-gcY0fCo0Oxii17Tr94sDhiIy7EynAgMBAAECgYBPeLA1viSN1JONlJ1IcHsRUZiW
-miTDSBp1BKpe5LJ8hkqfuTvRWU1DKc97dLB3lBSC8yEnAGPmzDa629Y3QNBSVtC2
-35NmJV0B3M8IX3PIMBYlI4dPjGKuNaHv+Es43fY404F1VY4e5o8emPzydLzTziI5
-NWznzvllwqC3cSAMoQJBAPgAwkrcej4XzBCrL0601U+amq3jbDSRxZUIyiXgtOUR
-6+XPh54qMTB2nxef6yV5svuxbcIYEA5lmBciX8fQcnECQQDUdWkDlE3Y9Nu//zG8
-iYyy24tGiXzLGePjavPFhZzPm8lv06Yj/oug1IK+ZwFvGqi4vq9c9XOjs4IfkIt6
-E4yXAkEAmlNulEMq1qTcWasM3z9sVgLxKjART40+lIVJtdRk/P7v+qvvyp6ayXun
-eH4NR965YCKDGHr80tipkgvT6nVuIQJAeOMdj6XQ7cPVTde8yxRQ9GwrQUV1tnLS
-0lHGxvsRkKeJ5JE/FXf+ptKEWiZuEHPQ0N3fFjurQtgfECrE0f9RnQJAdo6rrN8u
-SXEJ3VwldZK6RzERvAkPpD2HK5HAJ7r5+vnLVht1Zt0lL+vlTqiIM3MvalMlZB1v
-tPdBth0KXQr6Jg==
------END PRIVATE KEY-----
-"
+exports[`CryptoUtils getPrivateKey() 5: PEM PKCS#8 ECDSA 1`] = `
+{
+  "d": "T3iwNb4kjdSTjZSdSHB7EVGYlpokw0gadQSqXuSyfIZKn7k70VlNQynPe3Swd5QUgvMhJwBj5sw2utvWN0DQUlbQtt-TZiVdAdzPCF9zyDAWJSOHT4xirjWh7_hLON32ONOBdVWOHuaPHpj88nS8084iOTVs5875ZcKgt3EgDKE",
+  "dp": "mlNulEMq1qTcWasM3z9sVgLxKjART40-lIVJtdRk_P7v-qvvyp6ayXuneH4NR965YCKDGHr80tipkgvT6nVuIQ",
+  "dq": "eOMdj6XQ7cPVTde8yxRQ9GwrQUV1tnLS0lHGxvsRkKeJ5JE_FXf-ptKEWiZuEHPQ0N3fFjurQtgfECrE0f9RnQ",
+  "e": "AQAB",
+  "kty": "RSA",
+  "n": "zdJe-pIq1VRgSopnTQkMojIYqo176YJuLk4IeSWOe--aP2OX00vKGoQrZIe5JW0_9RIJ9L7osXyFKk2a4r4_gqURdJqca_S5tkUTcQsK_Kunj1X78Gk9RqJ87HfezJLPJDg2D0mVkPLmpVKBxjR8KjQ7GKLXtOv3iwOGIjLsTKc",
+  "p": "-ADCStx6PhfMEKsvTrTVT5qareNsNJHFlQjKJeC05RHr5c-HnioxMHafF5_rJXmy-7FtwhgQDmWYFyJfx9BycQ",
+  "q": "1HVpA5RN2PTbv_8xvImMstuLRol8yxnj42rzxYWcz5vJb9OmI_6LoNSCvmcBbxqouL6vXPVzo7OCH5CLehOMlw",
+  "qi": "do6rrN8uSXEJ3VwldZK6RzERvAkPpD2HK5HAJ7r5-vnLVht1Zt0lL-vlTqiIM3MvalMlZB1vtPdBth0KXQr6Jg",
+}
 `;
 
-exports[`CryptoUtils convertPrivateKeyToPem() 4: PEM PKCS#8 DSA 1`] = `
-"-----BEGIN PRIVATE KEY-----
-MIIBWwIBADCCATMGByqGSM44BAEwggEmAoGBAJFoQkSiL3fBz2gn8ZslqNxDXs9Y
-MjVqz0rWhGV1RaI4h13G7fCSF08PDfhO85PykJDQt4fXu0ixzMtvpxe30F88B4eN
-xvdCexe7pTQ6y4k0dk7qPkf7y4kB2quHXh40C96zEXbQk8HGB25y+Ejk7QrViD7a
-hI1BfUGvVN7ebZxrAh0A2r/w+CvfXziwX9jVEXEgSeAKhT/RZOm+whGs1QKBgC3a
-ofB/kY+sKdFcM5GR6HlfQ3s1v0/kgW2eMc8yPpDJD5bTOoqnxVUrUWmlSgUcFP/e
-lqOOlJyxjph69w52Ev03DR94GyDaG8kc5mvZI2c4FhwP0/fbxiZ74hH52PQ4gmVF
-fblwgD3g/Osvnzgda3bU5ppriblosjeofJQosAKxBB8CHQCmfX6t6QEwqaEzjo10
-OiURiSrPsSH2dizYK1Wa
------END PRIVATE KEY-----
-"
+exports[`CryptoUtils getPrivateKey() 6: PEM PKCS#8 ED25519 1`] = `
+{
+  "crv": "P-256",
+  "d": "-RC9AdyPFXArluWk6KMDJZnRg6aXNXx4mTk3uwwKSqg",
+  "kty": "EC",
+  "x": "DymV0MRNFZOUvBc5-1bI9H-PA4qY7NlF2sf4xew1w8A",
+  "y": "ebqNoUCJImoX1IvZdHb7QNiBv02S4fjhdCE3GQ92WQ8",
+}
 `;
 
-exports[`CryptoUtils convertPrivateKeyToPem() 5: PEM PKCS#8 ECDSA 1`] = `
-"-----BEGIN PRIVATE KEY-----
-MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg+RC9AdyPFXArluWk
-6KMDJZnRg6aXNXx4mTk3uwwKSqihRANCAAQPKZXQxE0Vk5S8Fzn7Vsj0f48Dipjs
-2UXax/jF7DXDwHm6jaFAiSJqF9SL2XR2+0DYgb9NkuH44XQhNxkPdlkP
------END PRIVATE KEY-----
-"
+exports[`CryptoUtils getPrivateKey() 7: PEM PKCS#8 ED25519 Encrypted 1`] = `
+{
+  "crv": "Ed25519",
+  "d": "EVBej4SZp1F00OIGC7iHOg77j5oHJ64Tl-bmwa4xL_s",
+  "kty": "OKP",
+  "x": "qZWTR-5H4FEh_HkZPNMh0lVmZky5TbpsLWQBaTFnN4A",
+}
 `;
 
-exports[`CryptoUtils convertPrivateKeyToPem() 6: PEM PKCS#8 ED25519 1`] = `
-"-----BEGIN PRIVATE KEY-----
-MFECAQEwBQYDK2VwBCIEIBFQXo+EmadRdNDiBgu4hzoO+4+aByeuE5fm5sGuMS/7
-gSEAqZWTR+5H4FEh/HkZPNMh0lVmZky5TbpsLWQBaTFnN4A=
------END PRIVATE KEY-----
-"
+exports[`CryptoUtils getPrivateKey() 8: OpenSSH RSA 1`] = `
+{
+  "crv": "Ed25519",
+  "d": "e1hMcHhkbE6jxIa0R-gupTYvT3iIF1o2e93LmLTQfHQ",
+  "kty": "OKP",
+  "x": "vwEr3F6eO4dtGsQcaX3GWhP7jeG4JuIJBzhAPo11D08",
+}
 `;
 
-exports[`CryptoUtils convertPrivateKeyToPem() 7: PEM PKCS#8 ED25519 Encrypted 1`] = `
-"-----BEGIN PRIVATE KEY-----
-MFECAQEwBQYDK2VwBCIEIHtYTHB4ZGxOo8SGtEfoLqU2L094iBdaNnvdy5i00Hx0
-gSEAvwEr3F6eO4dtGsQcaX3GWhP7jeG4JuIJBzhAPo11D08=
------END PRIVATE KEY-----
-"
+exports[`CryptoUtils getPrivateKey() 9: OpenSSH ECDSA 1`] = `
+{
+  "d": "QXrH1tSvdkTqt2o02Sd8SwVOEvSQDouZUdIaXlrYG3wd9EfO5_yn8Vl8jBSqYRFCbXL2bWagfmyR3_Gcy1vWpvsTavcxBjdjIttrPF0WhtPbFoy48mGhXIyTWor56248e6J37mFFtkR_gfRjnvS5JANhpPjoTLhvGioGzgYi44E",
+  "dp": "",
+  "dq": "",
+  "e": "AQAB",
+  "kty": "RSA",
+  "n": "yrB0SnD2N6xvlXYcxRgzTErJZfBE6RIJ7qE0lEF3-aqzP5Ls5J6jjIUTwI8MHMX0eSxNMjdm1pycqbWS8mq4HwOwcAslObACU7BVm9yaKZVGbzFWr2Yps13wYgHC0HJzQ0biolsOk0lpABV3Sn1icY80MTQExV0R2NaJLsgSkXU",
+  "p": "63p9Gf5U4UOCXBopSA4VV38o5FfTpmpvomJgP3d1qGFTxi0yx9mL4LC9QJKdP8Dyxad66FhCIlEi_2iWzBFUCQ",
+  "q": "3FpwwheX2knXle-c2RhK3acIr2CqMPl4eextcPxkgkva6WCj8Ms10D_ZWN1I4KuxCHQW8qpdZgrS2J1s1KwlDQ",
+  "qi": "VLeQAI-oCOq9DjW16fyKM7anxNZW3WJ81CMAbsVFOhOvN5hEXj8wQzyjzWxk1BZSOiM95MVL6r2q4gG5DE0Xnw",
+}
 `;
 
-exports[`CryptoUtils convertPrivateKeyToPem() 8: OpenSSH RSA 1`] = `
-"-----BEGIN PRIVATE KEY-----
-MIIB9wIBADANBgkqhkiG9w0BAQEFAASCAeEwggHdAgEAAoGBAMqwdEpw9jesb5V2
-HMUYM0xKyWXwROkSCe6hNJRBd/mqsz+S7OSeo4yFE8CPDBzF9HksTTI3ZtacnKm1
-kvJquB8DsHALJTmwAlOwVZvcmimVRm8xVq9mKbNd8GIBwtByc0NG4qJbDpNJaQAV
-d0p9YnGPNDE0BMVdEdjWiS7IEpF1AgMBAAECgYBBesfW1K92ROq3ajTZJ3xLBU4S
-9JAOi5lR0hpeWtgbfB30R87n/KfxWXyMFKphEUJtcvZtZqB+bJHf8ZzLW9am+xNq
-9zEGN2Mi22s8XRaG09sWjLjyYaFcjJNaivnrbjx7onfuYUW2RH+B9GOe9LkkA2Gk
-+OhMuG8aKgbOBiLjgQJBAOt6fRn+VOFDglwaKUgOFVd/KORX06Zqb6JiYD93dahh
-U8YtMsfZi+CwvUCSnT/A8sWneuhYQiJRIv9olswRVAkCQQDcWnDCF5faSdeV75zZ
-GErdpwivYKow+Xh57G1w/GSCS9rpYKPwyzXQP9lY3Ujgq7EIdBbyql1mCtLYnWzU
-rCUNAgEAAgEAAkBUt5AAj6gI6r0ONbXp/IoztqfE1lbdYnzUIwBuxUU6E683mERe
-PzBDPKPNbGTUFlI6Iz3kxUvqvariAbkMTRef
------END PRIVATE KEY-----
-"
+exports[`CryptoUtils getPrivateKey() 10: OpenSSH ED25519 1`] = `
+{
+  "crv": "P-256",
+  "d": "LBIrlWvr1ioOIXQpJaWrvFTDtyPX82rRKy9co6BZNrg",
+  "kty": "EC",
+  "x": "XO26UxPR1doE9esP7RKS7LwM5Bt456oZR2GPduPP-EE",
+  "y": "8SEHztEjs_ZN9LS7D2ecOXmSh069aonmruKtZdXUkwE",
+}
 `;
 
-exports[`CryptoUtils convertPrivateKeyToPem() 9: OpenSSH ECDSA 1`] = `
-"-----BEGIN PRIVATE KEY-----
-MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgLBIrlWvr1ioOIXQp
-JaWrvFTDtyPX82rRKy9co6BZNrihRANCAARc7bpTE9HV2gT16w/tEpLsvAzkG3jn
-qhlHYY9248/4QfEhB87RI7P2TfS0uw9nnDl5kodOvWqJ5q7irWXV1JMB
------END PRIVATE KEY-----
-"
+exports[`CryptoUtils getPrivateKey() 11: OpenSSH ED25519 Encrypted 1`] = `
+{
+  "crv": "Ed25519",
+  "d": "evSJ38PaEsGn4mfJYSJ3dNfe6G1MANPga7Xsv-Gb6HU",
+  "kty": "OKP",
+  "x": "A2T-HCZ3LJ6ss5Y8BZGXvzlE-438qqfWA4rWyG8eyd0",
+}
 `;
 
-exports[`CryptoUtils convertPrivateKeyToPem() 10: OpenSSH ED25519 1`] = `
-"-----BEGIN PRIVATE KEY-----
-MFECAQEwBQYDK2VwBCIEIHr0id/D2hLBp+JnyWEid3TX3uhtTADT4Gu17L/hm+h1
-gSEAA2T+HCZ3LJ6ss5Y8BZGXvzlE+438qqfWA4rWyG8eyd0=
------END PRIVATE KEY-----
-"
+exports[`CryptoUtils getPrivateKey() 12: DNSSEC RSASHA512 1`] = `
+{
+  "crv": "Ed25519",
+  "d": "_JJgrN2LFsG4XZIChhsFO5HHsXz_-j7GgyJQ8tNfW38",
+  "kty": "OKP",
+  "x": "Sw-zS0kVH8li5P8zBVlVJ5kQ-oPLE33Gwbof8GhmeEs",
+}
 `;
 
-exports[`CryptoUtils convertPrivateKeyToPem() 11: OpenSSH ED25519 Encrypted 1`] = `
-"-----BEGIN PRIVATE KEY-----
-MFECAQEwBQYDK2VwBCIEIPySYKzdixbBuF2SAoYbBTuRx7F8//o+xoMiUPLTX1t/
-gSEASw+zS0kVH8li5P8zBVlVJ5kQ+oPLE33Gwbof8GhmeEs=
------END PRIVATE KEY-----
-"
+exports[`CryptoUtils getPrivateKey() 13: JWK RSA 1`] = `
+{
+  "alg": "RS512",
+  "d": "hCC_zyLXg8xvxLmWE3aYK1Mumx2PiawkV2MZRk3kgsLL-jK-Czi2G-D4Wf78B4qZgCB7fairMNZVAeRtc8riB4s4WRNaXKjZkfsjW1UjEmKyO_P598fhURhJCsxpvRZRaDe_D1OT5No_Aj9pAZBqxhl9xVZ-MORbXBt8rgUIfUE",
+  "dp": "AW42Ll4X1XRLbZA8wtxwQZbSd5bYi6eTuCM9aJz9PzlNbDSThWBkbqJmjBNsZsP_apJCray7RGqjNdMB761YcQ",
+  "dq": "o3ufFdMT6qz51sqQ712uGALfKzqFPVIe-hHdq3rgzFyXQPFzut5AMBUdqB0wXKGGzp9LixBj0naO0eeqtykiYQ",
+  "e": "AQAB",
+  "kid": "1I0-T7JGu5fjmu-M6PaNbd1IvcN49qK8uDGPy4bTaZo",
+  "kty": "RSA",
+  "n": "krSAxyxXaeHsoqYZSkSRlIx61oHbYesYUzOMwmwEC4inVNVWKECB_teim6yzbhM8RI2HL2JOGeY8l0S8kAv2CoNT9JoZavjD65cDiVFD2nN71LJGslkDpXpbpS_n7lkovooV7YfF9EPb8wwEaHXZMd7ZoAjS3MpQPFhUY85_fPU",
+  "p": "38A4kFvFEcv-sPqzE6xeG4q5_SLoekVE3cKf_JPFeeufKigoS7VX_0ltqABKp6bohP7uPfWT8oAT1V1VWCcs0Q",
+  "q": "p9mCXS5mmKkJrCZGfy0h3yZOJkiDIKi_hwu95VcX_vZ8SM1LKJgwDjPWyvGxPZPC-fXm86Gaj6aN6Q3AJc-G5Q",
+  "qi": "l2m2wzcOpgI4zaD4yCB880Kg4s4iUz_k3vWgvjhWrqPmor5zPDdWp1LEwRFyoWdGPJg2vqALzE_57Nc3hNLa5A",
+  "use": "sig",
+}
 `;
 
-exports[`CryptoUtils convertPrivateKeyToPem() 12: DNSSEC RSASHA512 1`] = `
-"-----BEGIN PRIVATE KEY-----
-MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAPcPQM0iC92t9dqL
-4FEzH8O6gsxGdlJGKJ164O9W9w18Ap3BhVy0ORAd5slnm8h83/TpJIJCWcfXNTj8
-t++X5qF3rokORRJRDQFXXTyPr75DAUG18Bkb51VxPwJM+4Nb0/i3ahK9R/8JmD1K
-9/bcHQ0JULcFjvw9baaLwZ3+2CN/AgMBAAECgYAAp+u2H7cEWafjcqefz5DwBhi+
-zhkWUtVcxay/Ne3l/URMgu0Ft/zGzC2Gr128hIhbsBrGtcJjQ3ECu7kJS8/y8HaE
-0zku19+3eh6bIekgtLzbsgQXkgqjVlXxkkQmG+1C9J3rknMyDsoV9ncSBd1VIHKv
-rvRBPysIr9VlbTWc0QJBAP4jL/y9iCmonEMtnOc2LlC4Wgy3B1275qS9fVL4t5Ie
-U+sOulPNfh1aFP0aawMUlV7keYJ7986ukz3sGXFThusCQQD43slDimJYl19vSEOt
-+iBUB4g2xutLGrELW2c+Gci77EDuYPPSR7vLqeyknwkAO/l1u37G198HWEzg1psz
-tpi9AkEA93i4X/sIPtjL4bbnFVdzXnNGbR9F8wbon/9NrKA50fXqbfjXhIeUiWyR
-B67UChnfIpqFoISrWP4yr5fbZrmZpQJAL1eaK8oAaV/qXK3/ifICAloodFsk2XWr
-ZkCuBCc9g1ovA+nXmBHjTJv3k11ZhfziuJ3BQSxBlhEbFs5cWdsLdQJBAM2FmHTd
-o8MzaeRdiyTKqnWt9Qc1IRzA5L9TRP99yLyNgS/7ZsdjDURH2rh0OT9P2vW40EdH
-W9Q78lr7GdSK8ZE=
------END PRIVATE KEY-----
-"
+exports[`CryptoUtils getPrivateKey() 13: JWK RSA 2`] = `
+{
+  "d": "p-u2H7cEWafjcqefz5DwBhi-zhkWUtVcxay_Ne3l_URMgu0Ft_zGzC2Gr128hIhbsBrGtcJjQ3ECu7kJS8_y8HaE0zku19-3eh6bIekgtLzbsgQXkgqjVlXxkkQmG-1C9J3rknMyDsoV9ncSBd1VIHKvrvRBPysIr9VlbTWc0Q",
+  "dp": "93i4X_sIPtjL4bbnFVdzXnNGbR9F8wbon_9NrKA50fXqbfjXhIeUiWyRB67UChnfIpqFoISrWP4yr5fbZrmZpQ",
+  "dq": "L1eaK8oAaV_qXK3_ifICAloodFsk2XWrZkCuBCc9g1ovA-nXmBHjTJv3k11ZhfziuJ3BQSxBlhEbFs5cWdsLdQ",
+  "e": "AQAB",
+  "kty": "RSA",
+  "n": "9w9AzSIL3a312ovgUTMfw7qCzEZ2UkYonXrg71b3DXwCncGFXLQ5EB3myWebyHzf9OkkgkJZx9c1OPy375fmoXeuiQ5FElENAVddPI-vvkMBQbXwGRvnVXE_Akz7g1vT-LdqEr1H_wmYPUr39twdDQlQtwWO_D1tpovBnf7YI38",
+  "p": "_iMv_L2IKaicQy2c5zYuULhaDLcHXbvmpL19Uvi3kh5T6w66U81-HVoU_RprAxSVXuR5gnv3zq6TPewZcVOG6w",
+  "q": "-N7JQ4piWJdfb0hDrfogVAeINsbrSxqxC1tnPhnIu-xA7mDz0ke7y6nspJ8JADv5dbt-xtffB1hM4NabM7aYvQ",
+  "qi": "zYWYdN2jwzNp5F2LJMqqda31BzUhHMDkv1NE_33IvI2BL_tmx2MNREfauHQ5P0_a9bjQR0db1DvyWvsZ1IrxkQ",
+}
 `;
 
-exports[`CryptoUtils convertPrivateKeyToPem() 13: JWK RSA 1`] = `
-"-----BEGIN PRIVATE KEY-----
-MIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAJK0gMcsV2nh7KKm
-GUpEkZSMetaB22HrGFMzjMJsBAuIp1TVVihAgf7Xopuss24TPESNhy9iThnmPJdE
-vJAL9gqDU/SaGWr4w+uXA4lRQ9pze9SyRrJZA6V6W6Uv5+5ZKL6KFe2HxfRD2/MM
-BGh12THe2aAI0tzKUDxYVGPOf3z1AgMBAAECgYEAhCC/zyLXg8xvxLmWE3aYK1Mu
-mx2PiawkV2MZRk3kgsLL+jK+Czi2G+D4Wf78B4qZgCB7fairMNZVAeRtc8riB4s4
-WRNaXKjZkfsjW1UjEmKyO/P598fhURhJCsxpvRZRaDe/D1OT5No/Aj9pAZBqxhl9
-xVZ+MORbXBt8rgUIfUECQQDfwDiQW8URy/6w+rMTrF4birn9Iuh6RUTdwp/8k8V5
-658qKChLtVf/SW2oAEqnpuiE/u499ZPygBPVXVVYJyzRAkEAp9mCXS5mmKkJrCZG
-fy0h3yZOJkiDIKi/hwu95VcX/vZ8SM1LKJgwDjPWyvGxPZPC+fXm86Gaj6aN6Q3A
-Jc+G5QJAAW42Ll4X1XRLbZA8wtxwQZbSd5bYi6eTuCM9aJz9PzlNbDSThWBkbqJm
-jBNsZsP/apJCray7RGqjNdMB761YcQJBAKN7nxXTE+qs+dbKkO9drhgC3ys6hT1S
-HvoR3at64Mxcl0Dxc7reQDAVHagdMFyhhs6fS4sQY9J2jtHnqrcpImECQQCXabbD
-Nw6mAjjNoPjIIHzzQqDiziJTP+Te9aC+OFauo+aivnM8N1anUsTBEXKhZ0Y8mDa+
-oAvMT/ns1zeE0trk
------END PRIVATE KEY-----
-"
-`;
-
-exports[`CryptoUtils convertPrivateKeyToPem() 14: JWK ECDSA 1`] = `
-"-----BEGIN PRIVATE KEY-----
-MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQg9BFuyjbx1c8yaaCN
-FejA3x7835+7nvdGjoLqnnlz3jugCgYIKoZIzj0DAQehRANCAAR7H/hmaujipb66
-kq9Z4LoAsou2es4hb7C3Lh2BHfpKoZYAcrz8KDbkG5kmp36u/TcEEtjUlvpRKd/A
-pN91QJe8
------END PRIVATE KEY-----
-"
+exports[`CryptoUtils getPrivateKey() 14: JWK ECDSA 1`] = `
+{
+  "alg": "ES512",
+  "crv": "P-256",
+  "d": "9BFuyjbx1c8yaaCNFejA3x7835-7nvdGjoLqnnlz3js",
+  "kid": "vU8zJFV3uX6bU6sKzdBb3Efv9g4ZngrtxdGFoTizIqk",
+  "kty": "EC",
+  "use": "sig",
+  "x": "ex_4Zmro4qW-upKvWeC6ALKLtnrOIW-wty4dgR36SqE",
+  "y": "lgByvPwoNuQbmSanfq79NwQS2NSW-lEp38Ck33VAl7w",
+}
 `;

--- a/src/utils/CryptoUtils.test.ts
+++ b/src/utils/CryptoUtils.test.ts
@@ -38,8 +38,8 @@ describe('CryptoUtils', () => {
     test('1: Test not providing a key', async () => {
       try {
         await getPrivateKey({ key: '' })
-      } catch (e) {
-        expect(e).toStrictEqual(new FrodoError('Private key not provided.'));
+      } catch (error) {
+        expect(error).toStrictEqual(new FrodoError('Private key not provided.'));
       }
     });
 
@@ -51,9 +51,13 @@ describe('CryptoUtils', () => {
       testSuccess('pkcs8Rsa.pem');
     });
 
-    // test('4: PEM PKCS#8 DSA', () => {
-    //   testSuccess('pkcs8Dsa.pem');
-    // });
+    test('4: PEM PKCS#8 DSA', async () => {
+      try {
+        await testSuccess('pkcs8Dsa.pem')
+      } catch (error) {
+        expect(error).toStrictEqual(new FrodoError('Private key not supported.'));
+      }
+    });
 
     test('5: PEM PKCS#8 ECDSA', () => {
       testSuccess('pkcs8Ecdsa.pem');

--- a/src/utils/CryptoUtils.test.ts
+++ b/src/utils/CryptoUtils.test.ts
@@ -6,20 +6,21 @@
  * Note: FRODO_DEBUG=1 is optional and enables debug logging for some output
  * in case things don't function as expected
  */
-import { convertPrivateKeyToPem } from './CryptoUtils';
+import { getPrivateKey } from './CryptoUtils';
 import fs from 'fs'
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { FrodoError } from '../ops/FrodoError';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 describe('CryptoUtils', () => {
-  describe('convertPrivateKeyToPem()', () => {
+  describe('getPrivateKey()', () => {
     test('0: Method is implemented', async () => {
-      expect(convertPrivateKeyToPem).toBeDefined();
+      expect(getPrivateKey).toBeDefined();
     });
 
-    function testSuccess(filename: string, usePassphrase = false) {
+    async function testSuccess(filename: string, usePassphrase = false) {
       const key = fs.readFileSync(
         path.resolve(
           __dirname,
@@ -27,15 +28,19 @@ describe('CryptoUtils', () => {
         ),
         'utf8'
       );
-      const pem = convertPrivateKeyToPem({
+      const jwk = await getPrivateKey({
         key, 
         passphrase: usePassphrase ? 'test' : undefined
       });
-      expect(pem).toMatchSnapshot();
+      expect(jwk).toMatchSnapshot();
     }
 
-    test('1: Test not providing a key', () => {
-      expect(() => convertPrivateKeyToPem({ key: '' })).toThrow('Private key not provided.');
+    test('1: Test not providing a key', async () => {
+      try {
+        await getPrivateKey({ key: '' })
+      } catch (e) {
+        expect(e).toStrictEqual(new FrodoError('Private key not provided.'));
+      }
     });
 
     test('2: PEM PKCS#1 RSA', () => {
@@ -46,9 +51,9 @@ describe('CryptoUtils', () => {
       testSuccess('pkcs8Rsa.pem');
     });
 
-    test('4: PEM PKCS#8 DSA', () => {
-      testSuccess('pkcs8Dsa.pem');
-    });
+    // test('4: PEM PKCS#8 DSA', () => {
+    //   testSuccess('pkcs8Dsa.pem');
+    // });
 
     test('5: PEM PKCS#8 ECDSA', () => {
       testSuccess('pkcs8Ecdsa.pem');

--- a/src/utils/CryptoUtils.ts
+++ b/src/utils/CryptoUtils.ts
@@ -1,5 +1,6 @@
+import { createHash, createPrivateKey } from 'crypto';
+
 import sshpk from 'sshpk';
-import * as jose from 'jose';
 
 import { FrodoError } from '../ops/FrodoError';
 import { JwkRsa } from '../ops/JoseOps';
@@ -66,60 +67,75 @@ export async function getPrivateKey({
   } catch (error) {
     /* Ignore error since private key may still be a supported format */
   }
-  // Will automatically detect the format the private key is in and parse it if it is able to
-  const privateKey = sshpk.parsePrivateKey(key, 'auto', {
-    filename: name,
-    passphrase,
-  });
 
-  // Manually create the JWK to be imported -> exported if the key is provided with a curve and has 'parts'
-  //@ts-expect-error k does exist in part
-  if (privateKey.curve && privateKey.part.k) {
-    //@ts-expect-error k does exist in part
-    const seed = privateKey.part.k.data; // 32 bytes, the private key
-    //@ts-expect-error A does exist in part
-    const pubKey = privateKey.toPublic().part.A.data; // 32 bytes, the public key
+  try {
+    // Will automatically detect the format the private key is in and parse it if it is able to
+    const privateKey = sshpk.parsePrivateKey(key, 'auto', {
+      filename: name,
+      passphrase,
+    });
 
-    // base64url encode without padding
-    function b64url(bytes) {
-      return btoa(String.fromCharCode(...bytes))
-        .replace(/\+/g, '-')
-        .replace(/\//g, '_')
-        .replace(/=+$/, '');
+    let jwk;
+
+    // Due to how sshpk is specifically parsing ed25519-based keys, the JWK needs to
+    // be created manually and then passed to the 'createPrivateKey' function
+    if (privateKey.type === 'ed25519') {
+      const manualJwk = {
+        kty: 'OKP',
+        crv: 'Ed25519',
+        // @ts-expect-error A does exist
+        x: privateKey.toPublic().part.A.data.toString('base64url'),
+        // @ts-expect-error k does exist
+        d: privateKey.part.k.data.toString('base64url'),
+      };
+      jwk = createPrivateKey({ key: manualJwk, format: 'jwk' }).export({
+        format: 'jwk',
+      }) as JwkRsa;
+    } else {
+      jwk = createPrivateKey({
+        key: privateKey.toString('pkcs8'),
+      }).export({ format: 'jwk' }) as JwkRsa;
     }
 
-    const jwk = {
-      kty: 'OKP',
-      crv: 'Ed25519',
-      d: b64url(seed),
-      x: b64url(pubKey),
-    } as jose.JWK;
+    jwk.kid = generateThumbprint(jwk);
 
-    // @ts-expect-error the returned value is in JwkRsa format
-    return jose.exportJWK(
-      await jose.importJWK(jwk, 'EdDSA', { extractable: true })
-    ) as JwkRsa;
-  } else {
-    let pemKey;
+    console.log(jwk.kid);
 
-    try {
-      // ECDSA- or Ed25519-based algorithm
-      pemKey = await jose.importPKCS8(
-        privateKey.toBuffer('pkcs8').toString('utf8'),
-        'ES256',
-        { extractable: true }
-      );
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (e) {
-      // RSA-based algorithm
-      pemKey = await jose.importPKCS8(
-        privateKey.toBuffer('pkcs8').toString('utf8'),
-        'RS256',
-        { extractable: true }
-      );
+    return jwk;
+  } catch (error) {
+    if (error.name === 'KeyEncryptedError') {
+      throw new FrodoError(error.message);
     }
 
-    //@ts-expect-error the returned value is in JwkRsa format
-    return jose.exportJWK(pemKey) as JwkRsa;
+    throw new FrodoError(`Private key${name ? ` ${name}` : ''} not supported.`);
   }
+}
+
+/**
+ * This generates a deterministic value for the kid property that is missing due to
+ * the 'crypto' library not generating it
+ * @param {JwkRsa} jwk The JWK
+ * @returns {string} The kid value for the JWK
+ */
+function generateThumbprint(jwk) {
+  let canonical;
+  switch (jwk.kty) {
+    case 'RSA':
+      canonical = { e: jwk.e, kty: 'RSA', n: jwk.n };
+      break;
+    case 'EC':
+      canonical = { crv: jwk.crv, kty: 'EC', x: jwk.x, y: jwk.y };
+      break;
+    case 'OKP':
+      canonical = { crv: jwk.crv, kty: 'OKP', x: jwk.x };
+      break;
+    case 'oct':
+      canonical = { k: jwk.k, kty: 'oct' };
+      break;
+    default:
+      throw new Error(`Unsupported kty for thumbprint: ${jwk.kty}`);
+  }
+  // Members must be in lexicographic order with no whitespace — the literals above are already ordered
+  const json = JSON.stringify(canonical);
+  return createHash('sha256').update(json).digest('base64url');
 }

--- a/src/utils/CryptoUtils.ts
+++ b/src/utils/CryptoUtils.ts
@@ -1,53 +1,52 @@
-import jwkToPem from 'jwk-to-pem';
 import sshpk from 'sshpk';
+import * as jose from 'jose';
 
 import { FrodoError } from '../ops/FrodoError';
+import { JwkRsa } from '../ops/JoseOps';
 
 export type FrodoCrypto = {
   /**
-   * Parses a private key and returns it as an unencrypted PKCS#8 PEM encoded string
+   * Parses a private key and returns it
    * Supported private key formats include:
-   * - PEM (both PKCS#1 and PKCS#8 variants)
    * - OpenSSH
    * - DNSSEC
    * - JWK
    * @param {string} key The private key
    * @param {string | undefined} passphrase The passphrase for the private key if it is encrypted
    * @param {string | undefined} name The name of the private key (i.e. the name of the file it came from, if applicable); used for error handling
-   * @returns {string} The unencrypted PKCS#8 PEM encoded private key
+   * @returns {JwkRsa} The private key as JWK
    */
-  convertPrivateKeyToPem(
+  getPrivateKey(
     key: string,
     passphrase?: string,
     name?: string
-  ): string;
+  ): Promise<JwkRsa>;
 };
 
 export default (): FrodoCrypto => {
   return {
-    convertPrivateKeyToPem(
+    getPrivateKey(
       key: string,
       passphrase?: string,
       name?: string
-    ): string {
-      return convertPrivateKeyToPem({ key, passphrase, name });
+    ): Promise<JwkRsa> {
+      return getPrivateKey({ key, passphrase, name });
     },
   };
 };
 
 /**
- * Parses a private key and returns it as an unencrypted PKCS#8 PEM encoded string
+ * Parses a private key and returns it
  * Supported private key formats include:
- * - PEM (both PKCS#1 and PKCS#8 variants)
  * - OpenSSH
  * - DNSSEC
  * - JWK
  * @param {string} key The private key
  * @param {string | undefined} passphrase The passphrase for the private key if it is encrypted
  * @param {string | undefined} name The name of the private key (i.e. the name of the file it came from, if applicable); used for error handling
- * @returns {string} The unencrypted PKCS#8 PEM encoded private key
+ * @returns {JwkRsa} The unencrypted PKCS#8 PEM encoded private key
  */
-export function convertPrivateKeyToPem({
+export async function getPrivateKey({
   key,
   passphrase,
   name,
@@ -55,15 +54,14 @@ export function convertPrivateKeyToPem({
   key: string;
   passphrase?: string;
   name?: string;
-}): string {
+}): Promise<JwkRsa> {
   if (!key) {
     throw new FrodoError(`Private key${name ? ` ${name}` : ''} not provided.`);
   }
-  // Try converting JWK to PEM PKCS#8 format.
+  // Tries to return JWK
   try {
-    const jwk = JSON.parse(key);
-    // Need true flag to get the full private key
-    return jwkToPem(jwk, { private: true });
+    // Checks to see if key is valid JSON
+    return JSON.parse(key);
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
   } catch (error) {
     /* Ignore error since private key may still be a supported format */
@@ -73,5 +71,55 @@ export function convertPrivateKeyToPem({
     filename: name,
     passphrase,
   });
-  return privateKey.toString('pkcs8');
+
+  // Manually create the JWK to be imported -> exported if the key is provided with a curve and has 'parts'
+  //@ts-expect-error k does exist in part
+  if (privateKey.curve && privateKey.part.k) {
+    //@ts-expect-error k does exist in part
+    const seed = privateKey.part.k.data; // 32 bytes, the private key
+    //@ts-expect-error A does exist in part
+    const pubKey = privateKey.toPublic().part.A.data; // 32 bytes, the public key
+
+    // base64url encode without padding
+    function b64url(bytes) {
+      return btoa(String.fromCharCode(...bytes))
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '');
+    }
+
+    const jwk = {
+      kty: 'OKP',
+      crv: 'Ed25519',
+      d: b64url(seed),
+      x: b64url(pubKey),
+    } as jose.JWK;
+
+    // @ts-expect-error the returned value is in JwkRsa format
+    return jose.exportJWK(
+      await jose.importJWK(jwk, 'EdDSA', { extractable: true })
+    ) as JwkRsa;
+  } else {
+    let pemKey;
+
+    try {
+      // ECDSA- or Ed25519-based algorithm
+      pemKey = await jose.importPKCS8(
+        privateKey.toBuffer('pkcs8').toString('utf8'),
+        'ES256',
+        { extractable: true }
+      );
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (e) {
+      // RSA-based algorithm
+      pemKey = await jose.importPKCS8(
+        privateKey.toBuffer('pkcs8').toString('utf8'),
+        'RS256',
+        { extractable: true }
+      );
+    }
+
+    //@ts-expect-error the returned value is in JwkRsa format
+    return jose.exportJWK(pemKey) as JwkRsa;
+  }
 }


### PR DESCRIPTION
- fix!:Remove jwk-to-pem usage by modifying how keys are being formatted to always be JWK in the 'getPrivateKey' function
- fix:Fix tests to support the modifications in the function